### PR TITLE
Fix has_many declaration in Assignment concern

### DIFF
--- a/app/concerns/rails_workflow/user/assignment.rb
+++ b/app/concerns/rails_workflow/user/assignment.rb
@@ -4,7 +4,7 @@ module RailsWorkflow
       extend ActiveSupport::Concern
 
       included do
-        has_many :operations, class: RailsWorkflow::Operation, as: :assignment
+        has_many :operations, class_name: RailsWorkflow::Operation, as: :assignment
 
       end
 


### PR DESCRIPTION
`has_many` does not support a `:class` option, but it does support `:class_name`