### PR TITLE
Fix JSON importing bug related to ActiveModelSerializer settings

### DIFF
--- a/app/services/rails_workflow/process_importer.rb
+++ b/app/services/rails_workflow/process_importer.rb
@@ -1,6 +1,9 @@
 module RailsWorkflow
   class ProcessImporter
     def initialize json
+      if json['operations']
+        json['process_template']['operations'] = json['operations']
+      end
       @json = json['process_template']
     end
 
@@ -54,4 +57,3 @@ module RailsWorkflow
     end
   end
 end
-

--- a/app/services/rails_workflow/process_importer.rb
+++ b/app/services/rails_workflow/process_importer.rb
@@ -3,6 +3,7 @@ module RailsWorkflow
     def initialize json
       if json['operations']
         json['process_template']['operations'] = json['operations']
+        json['process_template'].delete('operation_ids')
       end
       @json = json['process_template']
     end


### PR DESCRIPTION
This PR fixes an issue where the client application may have ActiveModelSerializer configured to store associated records in the root of the JSON, rather than embedded within each record. This results in the `operations` of the exported JSON file to be at the root, e.g.,:
```
{"process_template":
   {"uuid":"8a85a519-8644-6146-f9aa-39ec1348a8c2",
     "title":"My Process",
     ... 
    "operation_ids":[1,2,3]
   },
 "operations": [ 
  { operation 1},
  { operation 2},
  { operation 3}
  ]
}
```
When you try to import this type of file back into Rails Workflow, the ProcessImporter class throws an exception on [this line](https://github.com/madzhuga/rails_workflow/blob/master/app/services/rails_workflow/process_importer.rb#L21) because `@json['operations']` is nil

This is caused by having an Active Model Serializer `config` like:
```
ActiveModel::Serializer.setup do |config|
  config.embed = :ids
  config.embed_in_root = true
end
```
Unfortunately there does not appear to be a way to configure a Rails Engine to not use the parent application's ActiveModelSerializer settings (or at least, I could not make it work by including an initializer in Rails Workflow that explicitly reset the `embed` values back to normal), so the `ProcessImporter` now copies the `operations` array back into the `process_template` hash if it is detected at root.