### PR TITLE
Fix after_operation_create

### DIFF
--- a/lib/rails_workflow/dependency_resolver.rb
+++ b/lib/rails_workflow/dependency_resolver.rb
@@ -25,7 +25,7 @@ module RailsWorkflow
             process, operation_template, completed_dependencies
           ).create_operation
         end
-      end
+      end.compact
     rescue => exception
       handle_exception(exception, operation)
     end

--- a/lib/rails_workflow/operation_builder.rb
+++ b/lib/rails_workflow/operation_builder.rb
@@ -23,7 +23,7 @@ module RailsWorkflow
       operation = operation_class.create(prepared_attributes) do |op|
         op.context = build_context(op, completed_dependencies)
         # Can add OperationTemplate#after_operation_create callback
-        after_opeartion_create(op) if respond_to?(:after_operation_create)
+        template.after_operation_create(op) if template.respond_to?(:after_operation_create)
       end
 
       build_child_process(operation)

--- a/lib/rails_workflow/process_runner.rb
+++ b/lib/rails_workflow/process_runner.rb
@@ -51,7 +51,7 @@ module RailsWorkflow
     def build_new_operations(operation)
       new_operations = dependency_resolver.build_new_operations(operation)
 
-      return unless new_operations
+      return if new_operations.blank?
 
       operations.concat(new_operations)
       operation_runner.start(new_operations)


### PR DESCRIPTION
These changes, plus renaming `build_operation` on `ProcessInvalidOrderTemplate` to `after_operation_create` allow the latest rails_workflow to work with the demo.