### PR TITLE
Update OperationTemplateDecorator

### DIFF
--- a/app/decorators/rails_workflow/operation_template_decorator.rb
+++ b/app/decorators/rails_workflow/operation_template_decorator.rb
@@ -38,7 +38,7 @@ module RailsWorkflow
     end
 
     def form
-      '_form'.prepend(object.kind)
+      '_form'.dup.prepend(object.kind)
     end
 
     def assignment


### PR DESCRIPTION
There's a string modifying function in this decorator that is causing problems when you try to add Operations. 
```ActionView::Template::Error (can't modify frozen String):
    18:       .panel-body
    19: 
    20:         = form_for [@process_template, @operation_template], html: {class: "form-horizontal clearfix"} do |f|
    21:           = render partial: @operation_template.form, locals: {f: f}
    22:           .form-group
    23:             = f.label :dependencies, class: "control-label col-sm-2"
    24:             .col-sm-10
```


`String.concat` appears to also modify the string in place, so I did this instead.