### PR TITLE
use root user class for operation_template_decorator as well

### DIFF
--- a/app/decorators/rails_workflow/operation_template_decorator.rb
+++ b/app/decorators/rails_workflow/operation_template_decorator.rb
@@ -46,11 +46,11 @@ module RailsWorkflow
     end
 
     def assignment_by_role
-      User.role_text(object.role) if object.role
+      ::User.role_text(object.role) if object.role
     end
 
     def assignment_by_group
-      User.group_text(object.group) if object.group
+      ::User.group_text(object.group) if object.group
     end
 
     def show_dependencies


### PR DESCRIPTION
Found another place where it needs `::` to work properly.